### PR TITLE
Fixed balance being incorrectly displayed without pence

### DIFF
--- a/ATM/Program.cs
+++ b/ATM/Program.cs
@@ -162,7 +162,7 @@ namespace ATM_forms
     public static class TransactionData
     {
         // transaction variables (dummy data for now)
-        public static string connectionAddress = "ec2-35-175-247-166.compute-1.amazonaws.com";
+        public static string connectionAddress = "ec2-52-91-1-195.compute-1.amazonaws.com";
         public static decimal CurrentBalance = 500;
         public static int transactionType = -1;
         public static int ATMID = 0;

--- a/ATM/balance_form.Designer.cs
+++ b/ATM/balance_form.Designer.cs
@@ -43,18 +43,20 @@ namespace ATM_forms
             this.balance_panel.Controls.Add(this.balance_label);
             this.balance_panel.Controls.Add(this.balance_heading_label);
             this.balance_panel.Controls.Add(this.done_btn);
-            this.balance_panel.Location = new System.Drawing.Point(508, 215);
+            this.balance_panel.Location = new System.Drawing.Point(339, 140);
+            this.balance_panel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.balance_panel.Name = "balance_panel";
-            this.balance_panel.Size = new System.Drawing.Size(1300, 900);
+            this.balance_panel.Size = new System.Drawing.Size(867, 585);
             this.balance_panel.TabIndex = 0;
             // 
             // balance_label
             // 
             this.balance_label.Font = new System.Drawing.Font("Segoe UI", 48F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.balance_label.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(2)))), ((int)(((byte)(7)))), ((int)(((byte)(93)))));
-            this.balance_label.Location = new System.Drawing.Point(207, 300);
+            this.balance_label.Location = new System.Drawing.Point(138, 195);
+            this.balance_label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.balance_label.Name = "balance_label";
-            this.balance_label.Size = new System.Drawing.Size(886, 108);
+            this.balance_label.Size = new System.Drawing.Size(591, 70);
             this.balance_label.TabIndex = 5;
             this.balance_label.Text = "£XXX.XX";
             this.balance_label.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -63,9 +65,10 @@ namespace ATM_forms
             // 
             this.balance_heading_label.Font = new System.Drawing.Font("Segoe UI", 36F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.balance_heading_label.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(2)))), ((int)(((byte)(7)))), ((int)(((byte)(93)))));
-            this.balance_heading_label.Location = new System.Drawing.Point(207, 20);
+            this.balance_heading_label.Location = new System.Drawing.Point(138, 13);
+            this.balance_heading_label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.balance_heading_label.Name = "balance_heading_label";
-            this.balance_heading_label.Size = new System.Drawing.Size(886, 108);
+            this.balance_heading_label.Size = new System.Drawing.Size(591, 70);
             this.balance_heading_label.TabIndex = 0;
             this.balance_heading_label.Text = "Balance";
             this.balance_heading_label.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -78,9 +81,10 @@ namespace ATM_forms
             this.done_btn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.done_btn.Font = new System.Drawing.Font("Segoe UI", 28F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.done_btn.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(2)))), ((int)(((byte)(7)))), ((int)(((byte)(93)))));
-            this.done_btn.Location = new System.Drawing.Point(390, 616);
+            this.done_btn.Location = new System.Drawing.Point(285, 418);
+            this.done_btn.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.done_btn.Name = "done_btn";
-            this.done_btn.Size = new System.Drawing.Size(440, 130);
+            this.done_btn.Size = new System.Drawing.Size(293, 84);
             this.done_btn.TabIndex = 4;
             this.done_btn.Text = "DONE";
             this.done_btn.UseVisualStyleBackColor = true;
@@ -90,10 +94,11 @@ namespace ATM_forms
             // 
             // BalanceForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1924, 1050);
+            this.ClientSize = new System.Drawing.Size(1283, 682);
             this.Controls.Add(this.balance_panel);
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.Name = "BalanceForm";
             this.Text = "Check balance";
             this.WindowState = System.Windows.Forms.FormWindowState.Maximized;

--- a/ATM/balance_form.cs
+++ b/ATM/balance_form.cs
@@ -42,8 +42,8 @@ namespace ATM_forms
                 Console.WriteLine($"Response: {response}");
                 NetworkClient.CloseConnection();
 
-                 dynamic parsedResponse = JsonConvert.DeserializeObject(response);
-                 int transaction_value = parsedResponse.transaction_value;
+                dynamic parsedResponse = JsonConvert.DeserializeObject(response);
+                double transaction_value = parsedResponse.transaction_value;
                 //int transaction_value = 100; //test data
 
                 balance_label.Text = $"£{transaction_value:F2}"; // F2 for two decimal places


### PR DESCRIPTION
Previously even when conversely stored in the logs and on the simulator, balances would appear as strictly integer values on the ATM's display balance screen.

## Description
Initially when the transaction amount was parsed from the JSON it parsed into an integer field, I have changed it now so that is not the case

## Link to Issue
Bug fix supplemental to #77 and #79 

## Motivation and Context
Given that we are now dealing with converted currencies, it is much more likely that a users balance will be an uneven amount. Therefore it is paramount for decimal values to be taken into consideration to ensure that a user's balance is displayed correctly

## How has this been tested?
I displayed the balance for an account which I authoritatively knew had an uneven balance 430.3 to be exact

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7598115d-096e-4c06-8b43-82a7b279ceaf)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code has been tested.
- [x] My code follows the code style of this project (See README).
- [x] My code is well commented.
- [x] My code is readable.
- [x] My code is tested.
