### PR TITLE
78 addendum

### DIFF
--- a/ATM/Program.cs
+++ b/ATM/Program.cs
@@ -115,7 +115,7 @@ namespace ATM_forms
             // notifies the user of the connection problem with a dialog box
             //MessageBox.Show("Problem with transaction, returning card...", "Connection Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 
-            AlertMessageForm alertMessageForm = new AlertMessageForm("Problem with transaction, returning card...");
+            AlertMessageForm alertMessageForm = new AlertMessageForm("Connection error, returning card...");
             alertMessageForm.ShowDialog();
 
             // gets the current form - which is the form where the connection failed so we can close it


### PR DESCRIPTION
Additional changes to improve error handling
## Description
Changed the error message displayed when the ATM fails to connect to the switch. It previously read 'problem with transaction' it now says 'connection error'

## Link to Issue
#78 
## Motivation and Context
The previous error text was ambiguous and wasn't clear enough that the user was not at fault

## How has this been tested?
I wilfully triggered the error and saw the new message

## Screenshots (if appropriate):
<!--- If you're feeling generous -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code has been tested.
- [ ] My code follows the code style of this project (See README).
- [x] My code is well commented.
- [ ] My code is readable.
- [x] My code is tested.
