### PR TITLE
fixed the double error message

### DIFF
--- a/ATM/enter_pin_form.cs
+++ b/ATM/enter_pin_form.cs
@@ -31,28 +31,9 @@ namespace ATM_forms
         private void PinTxtboxTextChanged(object sender, EventArgs e)
         {
             pin_txt_box.PasswordChar = '*';   // hides input 
-
-            // the text is only digits and has a maximum length of 4
-            if (!int.TryParse(pin_txt_box.Text, out _) || pin_txt_box.Text.Length > 4)
-            {
-                if (GlobalVariables.language == "french")
-                {
-                    AlertMessageForm alertMessage = new AlertMessageForm("Code PIN invalide. Veuillez saisir un code PIN à 4 chiffres.");
-                    alertMessage.Show(this);
-                }
-                else if (GlobalVariables.language == "english")
-                {
-                    AlertMessageForm alertMessage = new AlertMessageForm("Invalid PIN. Please enter a 4-digit PIN.");
-                    alertMessage.Show(this);
-                }
-                else if (GlobalVariables.language == "spanish")
-                {
-                    AlertMessageForm alertMessage = new AlertMessageForm("PIN no válido. Ingrese un PIN de 4 dígitos.");
-                    alertMessage.Show(this);
-                }
                 pin_txt_box.Text = pin_txt_box.Text.Substring(0, Math.Min(4, pin_txt_box.Text.Length));
                 pin_txt_box.SelectionStart = pin_txt_box.Text.Length; // moves the cursor to the end
-            }
+            
 
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Enter pin bug fix. It should only show one error message when a pin is wrong now.

## Link to Issue
<!--- Link to the issue this pull request is completing -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If resubmitting a failed push then how is it now compliant -->
The user won't be confused now.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Simulated a wrong pin and it only shows one error message.

## Screenshots (if appropriate):
<!--- If you're feeling generous -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code has been tested.
- [x] My code follows the code style of this project (See README).
- [x] My code is well commented.
- [x] My code is readable.
- [x] My code is tested.
